### PR TITLE
Improves Localization, Ignores Steam, adds non-polluting puddles

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -7,6 +7,12 @@ local mod_data_version = "0.13.0"
 --   end
 -- end
 
+-- Fluid types that will not make a spill
+local IGNORED_FLUIDS = {
+  ["steam"] = true,
+  ["water"] = true,
+}
+
 local function onTick(event)
   -- pollute once per second
   if event.tick % 60 == 41 then
@@ -67,7 +73,7 @@ local function fluidSpill(e)
   -- create a chemical spill for non-water fluids being destroyed
   if #e.fluidbox > 0 then
     for b = 1, #e.fluidbox do
-      if e.fluidbox[b] and e.fluidbox[b].type ~= "water" then
+      if e.fluidbox[b] and IGNORED_FLUIDS[e.fluidbox[b].type] ~= false then
         local spill_amount = e.fluidbox[b].amount
         local spill_size
         if spill_amount < settings.global['medium_spill_threshold'].value then

--- a/locale/en/wreckage-pollution.cfg
+++ b/locale/en/wreckage-pollution.cfg
@@ -16,8 +16,16 @@ chemical-spill-small=__1__ spill
 chemical-spill-medium=__1__ spill
 chemical-spill-large=__1__ spill
 
+liquid-spill-small=__1__ spill
+liquid-spill-medium=__1__ spill
+liquid-spill-large=__1__ spill
+
 
 [entity-description]
 chemical-spill-small=A small amount of __1__ was spilled here; Its a pollutant
 chemical-spill-medium=A moderate amount of __1__  was spilled here; Its a pollutant
 chemical-spill-large=A large amount of __1__ was spilled here; Its a pollutant
+
+liquid-spill-small=A small puddle of __1__
+liquid-spill-medium=A puddle of __1__
+liquid-spill-large=A large puddle of __1__

--- a/locale/en/wreckage-pollution.cfg
+++ b/locale/en/wreckage-pollution.cfg
@@ -9,3 +9,15 @@ pollution_intensity=Amount of pollution generated for new wreckage and spills.
 pollution_evaporation=Amount of a spill converted to pollution each second.
 medium_spill_threshold=More than this much liquid will produce a medium size chemical spill sprite.
 large_spill_threshold=More than this much liquid will produce a large size chemical spill sprite.
+
+
+[entity-name]
+chemical-spill-small=__1__ spill
+chemical-spill-medium=__1__ spill
+chemical-spill-large=__1__ spill
+
+
+[entity-description]
+chemical-spill-small=A small amount of __1__ was spilled here; Its a pollutant
+chemical-spill-medium=A moderate amount of __1__  was spilled here; Its a pollutant
+chemical-spill-large=A large amount of __1__ was spilled here; Its a pollutant

--- a/prototypes/entity-chemical-spill.lua
+++ b/prototypes/entity-chemical-spill.lua
@@ -8,21 +8,38 @@ local spill_sizes = {
   large =3
 }
 
+-- liquids that create non-polluting spills
+local non_pollutants = {
+  ["water"] = true,
+}
+
+
+
 for name, proto in pairs(data.raw.fluid) do
   for sizename, size in pairs(spill_sizes) do
+    -- See what kind of entity this liquid gets
+    local spill_type
+    if non_pollutants[name] == true then
+      spill_type = 'liquid-spill'
+    else
+      spill_type = 'chemical-spill'
+    end
+
     data:extend(
       {
         {
           type = "simple-entity",
-          name = "chemical-spill-" .. proto.name .. '-' .. sizename,
+          name = spill_type .. "-" .. proto.name .. '-' .. sizename,
           flags = {"placeable-neutral", "placeable-off-grid", "not-on-map"},
           icon = "__wreckage-pollution__/graphics/entity/chemical-spill-" .. sizename .. ".png",
           subgroup = "chemical-spill",
           order = "d[chemical-spill]-a[" .. proto.name .. "]-a[" .. sizename .. "]",
           selection_box = {{-size, -size}, {size, size}},
           selectable_in_game = true,
-          localised_name = {"entity-name.chemical-spill-" .. sizename, {"fluid-name." .. proto.name}},
-          localised_description = {"entity-description.chemical-spill-" .. sizename, {"fluid-name." .. proto.name}},
+          collision_box = {{-size, -size}, {size, size}},
+          collision_mask = {"floor-layer"},
+          localised_name = {"entity-name." .. spill_type .. "-" .. sizename, {"fluid-name." .. proto.name}},
+          localised_description = {"entity-description." .. spill_type .. "-" .. sizename, {"fluid-name." .. proto.name}},
 
           render_layer = "decorative",
           pictures =

--- a/prototypes/entity-chemical-spill.lua
+++ b/prototypes/entity-chemical-spill.lua
@@ -20,7 +20,10 @@ for name, proto in pairs(data.raw.fluid) do
           subgroup = "chemical-spill",
           order = "d[chemical-spill]-a[" .. proto.name .. "]-a[" .. sizename .. "]",
           selection_box = {{-size, -size}, {size, size}},
-          selectable_in_game = false,
+          selectable_in_game = true,
+          localised_name = {"entity-name.chemical-spill-" .. sizename, {"fluid-name." .. proto.name}},
+          localised_description = {"entity-description.chemical-spill-" .. sizename, {"fluid-name." .. proto.name}},
+
           render_layer = "decorative",
           pictures =
           {


### PR DESCRIPTION
This Pull request is 3 main features:

Chemical spills are given a locale translation, so you can hover on them and see a description about them in the correct language.
 * The locale descriptions are automatically generated based on the fluids they spawn from
   So you only need to translate this mod's descriptions/names

Water spills would look nice, so this adds non-polluting spills.
 * Now water spills (and any other such spills) still create puddles

Steam shouldn't make spills, that gets ignored

